### PR TITLE
correct transmission_index to match loops

### DIFF
--- a/source/stemcl.c
+++ b/source/stemcl.c
@@ -780,7 +780,7 @@ void calculateTransmissionLayer(const float x[], const float y[],
 }
 
 int transmission_index(int x, int y, int slice) {
-    return (slice * ny * nx + x * ny + y);
+    return (slice * ny * nx + y * nx + x);
 }
 
 double wavelength(double kev) {


### PR DESCRIPTION
corrects an error when running without hdd. The output was rotated 90 degrees when compared to the input file.